### PR TITLE
Update index.md - fix bug in demo.jl

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -50,7 +50,7 @@ function level_2_task(td)
             break
         end
         # send a data message to process named level_1_task
-        cast(td, "level_1_task", AppData(n))
+        cast("level_1_task", AppData(n))
         n += 1
     end
     @info "shutting down $td"


### PR DESCRIPTION
I believe `cast` was being called incorrectly.  It was given both a `Visor.Process` and a `String`, but in this context, I think it should be just the string so that a message gets sent to "level_1_task".

The demo didn't work as described until I made this change.